### PR TITLE
pfsense-theme-clearblue-3 Breadcrumbs are not displaying arrows on macOS

### DIFF
--- a/clearblue.css
+++ b/clearblue.css
@@ -207,11 +207,11 @@ a {
 }
 .breadcrumb > li + li::before {
   color: #2279C6;
-  content: "\f0da";
+  content: "\f054";
   display: inline-block;
   padding: 0 10px 0 10px;
   vertical-align: middle;
-  font: normal normal normal 17px/1 FontAwesome;
+  font: normal normal normal 11px/1 FontAwesome;
 }
 
 .context-links {

--- a/clearblue.css
+++ b/clearblue.css
@@ -1,7 +1,13 @@
-@charset "UTF-8";
 @import url("https://fonts.bunny.net/css?family=nunito-sans:400");
 @import url("/vendor/bootstrap/css/bootstrap.min.css");
 @import url("/vendor/jquery-ui/jquery-ui-1.12.1.min.css");
+@font-face {
+  font-family: "FontAwesome";
+  src: url("/vendor/font-awesome/fonts/fontawesome-webfont.eot?v=4.5.0");
+  src: url("/vendor/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0") format("embedded-opentype"), url("/vendor/font-awesome/fonts/fontawesome-webfont.woff2?v=4.5.0") format("woff2"), url("/vendor/font-awesome/fonts/fontawesome-webfont.woff?v=4.5.0") format("woff"), url("/vendor/font-awesome/fonts/fontawesome-webfont.ttf?v=4.5.0") format("truetype"), url("/vendor/font-awesome/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
 body {
   font-family: "Nunito Sans", sans-serif;
 }
@@ -201,10 +207,11 @@ a {
 }
 .breadcrumb > li + li::before {
   color: #2279C6;
-  content: "⮞";
+  content: "\f0da";
   display: inline-block;
   padding: 0 10px 0 10px;
   vertical-align: middle;
+  font: normal normal normal 20px/1 FontAwesome;
 }
 
 .context-links {

--- a/clearblue.css
+++ b/clearblue.css
@@ -211,7 +211,7 @@ a {
   display: inline-block;
   padding: 0 10px 0 10px;
   vertical-align: middle;
-  font: normal normal normal 20px/1 FontAwesome;
+  font: normal normal normal 17px/1 FontAwesome;
 }
 
 .context-links {

--- a/clearblue.css
+++ b/clearblue.css
@@ -1,13 +1,6 @@
 @import url("https://fonts.bunny.net/css?family=nunito-sans:400");
 @import url("/vendor/bootstrap/css/bootstrap.min.css");
 @import url("/vendor/jquery-ui/jquery-ui-1.12.1.min.css");
-@font-face {
-  font-family: "FontAwesome";
-  src: url("/vendor/font-awesome/fonts/fontawesome-webfont.eot?v=4.5.0");
-  src: url("/vendor/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0") format("embedded-opentype"), url("/vendor/font-awesome/fonts/fontawesome-webfont.woff2?v=4.5.0") format("woff2"), url("/vendor/font-awesome/fonts/fontawesome-webfont.woff?v=4.5.0") format("woff"), url("/vendor/font-awesome/fonts/fontawesome-webfont.ttf?v=4.5.0") format("truetype"), url("/vendor/font-awesome/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular") format("svg");
-  font-weight: normal;
-  font-style: normal;
-}
 body {
   font-family: "Nunito Sans", sans-serif;
 }
@@ -211,7 +204,8 @@ a {
   display: inline-block;
   padding: 0 10px 0 10px;
   vertical-align: middle;
-  font: normal normal normal 11px/1 FontAwesome;
+  font: normal normal normal 11px/1 "Font Awesome 5 Free";
+  font-weight: 900;
 }
 
 .context-links {

--- a/clearblue.scss
+++ b/clearblue.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.bunny.net/css?family=nunito-sans:400");
+﻿@import url("https://fonts.bunny.net/css?family=nunito-sans:400");
 @import url("/vendor/bootstrap/css/bootstrap.min.css");
 @import url("/vendor/jquery-ui/jquery-ui-1.12.1.min.css");
 
@@ -18,4 +18,3 @@
 @import "partials/buttons";
 @import "partials/progress";
 @import "partials/pfsense";
-

--- a/clearblue.scss
+++ b/clearblue.scss
@@ -3,6 +3,7 @@
 @import url("/vendor/jquery-ui/jquery-ui-1.12.1.min.css");
 
 @import "variables";
+@import "partials/font-awesome";
 @import "partials/base";
 @import "partials/jquery";
 @import "partials/sidebar";

--- a/clearblue.scss
+++ b/clearblue.scss
@@ -3,7 +3,6 @@
 @import url("/vendor/jquery-ui/jquery-ui-1.12.1.min.css");
 
 @import "variables";
-@import "partials/font-awesome";
 @import "partials/base";
 @import "partials/jquery";
 @import "partials/sidebar";

--- a/partials/_font-awesome.scss
+++ b/partials/_font-awesome.scss
@@ -1,0 +1,7 @@
+@font-face {
+    font-family: 'FontAwesome';
+    src: url('/vendor/font-awesome/fonts/fontawesome-webfont.eot?v=4.5.0');
+    src: url('/vendor/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0') format('embedded-opentype'), url('/vendor/font-awesome/fonts/fontawesome-webfont.woff2?v=4.5.0') format('woff2'), url('/vendor/font-awesome/fonts/fontawesome-webfont.woff?v=4.5.0') format('woff'), url('/vendor/font-awesome/fonts/fontawesome-webfont.ttf?v=4.5.0') format('truetype'), url('/vendor/font-awesome/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/partials/_font-awesome.scss
+++ b/partials/_font-awesome.scss
@@ -1,7 +1,0 @@
-@font-face {
-    font-family: 'FontAwesome';
-    src: url('/vendor/font-awesome/fonts/fontawesome-webfont.eot?v=4.5.0');
-    src: url('/vendor/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.5.0') format('embedded-opentype'), url('/vendor/font-awesome/fonts/fontawesome-webfont.woff2?v=4.5.0') format('woff2'), url('/vendor/font-awesome/fonts/fontawesome-webfont.woff?v=4.5.0') format('woff'), url('/vendor/font-awesome/fonts/fontawesome-webfont.ttf?v=4.5.0') format('truetype'), url('/vendor/font-awesome/fonts/fontawesome-webfont.svg?v=4.5.0#fontawesomeregular') format('svg');
-    font-weight: normal;
-    font-style: normal;
-}

--- a/partials/_header.scss
+++ b/partials/_header.scss
@@ -12,11 +12,11 @@
 
     & > li + li::before {
         color: $link-fg;
-        content: "\f0da";
+        content: "\f054";
         display: inline-block;
         padding: 0 10px 0 10px;
         vertical-align: middle;
-        font: normal normal normal 17px/1 FontAwesome;
+        font: normal normal normal 11px/1 FontAwesome;
     }
 }
 

--- a/partials/_header.scss
+++ b/partials/_header.scss
@@ -12,10 +12,11 @@
 
     & > li + li::before {
         color: $link-fg;
-        content: "\2B9E";
+        content: "\f0da";
         display: inline-block;
         padding: 0 10px 0 10px;
         vertical-align: middle;
+        font: normal normal normal 20px/1 FontAwesome;
     }
 }
 

--- a/partials/_header.scss
+++ b/partials/_header.scss
@@ -16,7 +16,7 @@
         display: inline-block;
         padding: 0 10px 0 10px;
         vertical-align: middle;
-        font: normal normal normal 20px/1 FontAwesome;
+        font: normal normal normal 17px/1 FontAwesome;
     }
 }
 

--- a/partials/_header.scss
+++ b/partials/_header.scss
@@ -16,7 +16,8 @@
         display: inline-block;
         padding: 0 10px 0 10px;
         vertical-align: middle;
-        font: normal normal normal 11px/1 FontAwesome;
+        font: normal normal normal 11px/1 "Font Awesome 5 Free";
+        font-weight: 900;
     }
 }
 


### PR DESCRIPTION
@sarabveer I'm assuming the issue is caused by incorrect character encoding detection. I've added a UTF-8 BOM to the CSS file which should help force the issue. 

If you could test out the version in this PR that'd be great